### PR TITLE
fix spawning zombie processes when one of the commands returns an error

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -9,6 +9,7 @@ import (
 // Command is a os/exec.Commnad wrapper for UNIX pipe
 func Command(stdout *bytes.Buffer, stack ...*exec.Cmd) (err error) {
 	var stderr bytes.Buffer
+
 	pipeStack := make([]*io.PipeWriter, len(stack)-1)
 	i := 0
 	for ; i < len(stack)-1; i++ {
@@ -18,6 +19,7 @@ func Command(stdout *bytes.Buffer, stack ...*exec.Cmd) (err error) {
 		stack[i+1].Stdin = inPipe
 		pipeStack[i] = outPipe
 	}
+
 	stack[i].Stdout = stdout
 	stack[i].Stderr = &stderr
 
@@ -34,12 +36,16 @@ func call(stack []*exec.Cmd, pipes []*io.PipeWriter) (err error) {
 		if err = stack[1].Start(); err != nil {
 			return err
 		}
+
 		defer func() {
+			pipes[0].Close()
 			if err == nil {
-				pipes[0].Close()
 				err = call(stack[1:], pipes[1:])
+			} else {
+				stack[1].Wait()
 			}
 		}()
 	}
+
 	return stack[0].Wait()
 }


### PR DESCRIPTION
First of all, thanks for the great package. I was using it and noticed that zombie processes would be left when one of the subprocesses would return an non-zero exit code. After bunch of tests and scratching my head, I was able to come up with a fix :)